### PR TITLE
Update pyproject.toml to resolve incompatible dependency versions.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,12 +16,12 @@ packages = [
 [tool.poetry.dependencies]
 python = "^3.8, <3.11"
 gradio = "^3.24.1"
-huggingface-hub = "^0.16.4"
+huggingface-hub = "^0.23.5"
 numpy = "^1.24.2"
 opencv_python = "^4.7.0.72"
-Pillow = "9.3.0"
-transformers = "^4.27.4"
-lightning = "^2.0.1"
+Pillow = "9.4.0"
+transformers = "^4.42.4"
+lightning = "^2.3.3"
 segment-anything = {git = "https://github.com/facebookresearch/segment-anything.git"}
 groundingdino = {git = "https://github.com/IDEA-Research/GroundingDINO.git"}
 


### PR DESCRIPTION
## Describe your changes and approach used
Earlier we had clashing versions of various repositories, as well as a "unable to import 'split_torch_state_dict_into_shards' from 'huggingface_hub' " error when attempting to fix that. The current versions of the dependencies however, work perfectly.

## Checklist before requesting a review
- [x]  I have performed a self-review of my code.
- [x] I have performed linting on my code.
- [x] I have linked the related issue.
- [x] The code is documented accordingly.
- [x] If it is a core feature, I have added thorough tests.
