### PR TITLE
Fix local checkpoint loading by indexing 'model' key and undefined va…

### DIFF
--- a/lang_sam/models/sam.py
+++ b/lang_sam/models/sam.py
@@ -55,7 +55,8 @@ class SAM:
             checkpoint_url = SAM_MODELS[self.sam_type]["url"]
             state_dict = torch.hub.load_state_dict_from_url(checkpoint_url, map_location="cpu")["model"]
         else:
-            state_dict = torch.load(self.ckpt_path, map_location="cpu", weights_only=True)
+            checkpoint_url = self.ckpt_path  # Ensure checkpoint_url is defined
+            state_dict = torch.load(self.ckpt_path, map_location="cpu", weights_only=True)["model"]
         try:
             model.load_state_dict(state_dict, strict=True)
         except Exception as e:


### PR DESCRIPTION
Updated local checkpoint loading to extract the model weights using ["model"] and defines checkpoint_url for local checkpoints, ensuring error messages reference the correct checkpoint path.

This PR addresses two issues in the `_load_checkpoint` function:

1. The local checkpoint loading did not extract the "model" key from the state dictionary, which could lead to errors.
2. The error message referenced `checkpoint_url` even when a local checkpoint was used, where `checkpoint_url` was not defined.

The changes ensure that both local and remote checkpoints are processed consistently and that error messages accurately reference the used checkpoint path.
