### PR TITLE
lang_sam.py and gdino.py are modified for local model loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,14 @@ text_prompt = "wheel."
 results = model.predict([image_pil], [text_prompt])
 ```
 
+If desired, arguments below can be passed for offline operations:
+```python
+LangSAM(sam_ckpt_path,              # path for segment anything model
+        gdino_model_ckpt_path,      # path for grounding dino's model checkpoint
+        gdino_processor_ckpt_path   # path for grounding dino's processor checkpoint
+)
+```
+
 ## Examples
 
 ![car.png](/assets/outputs/car.png)

--- a/lang_sam/lang_sam.py
+++ b/lang_sam/lang_sam.py
@@ -7,13 +7,13 @@ from lang_sam.models.utils import DEVICE
 
 
 class LangSAM:
-    def __init__(self, sam_type="sam2.1_hiera_small", ckpt_path: str | None = None, device=DEVICE):
+    def __init__(self, sam_type="sam2.1_hiera_small", sam_ckpt_path: str | None = None, gdino_model_ckpt_path: str | None = None, gdino_processor_ckpt_path: str | None = None, device=DEVICE):
         self.sam_type = sam_type
 
         self.sam = SAM()
-        self.sam.build_model(sam_type, ckpt_path, device=device)
+        self.sam.build_model(sam_type, sam_ckpt_path, device=device)
         self.gdino = GDINO()
-        self.gdino.build_model(device=device)
+        self.gdino.build_model(model_ckpt_path=gdino_model_ckpt_path, processor_ckpt_path=gdino_processor_ckpt_path, device=device)
 
     def predict(
         self,

--- a/lang_sam/models/gdino.py
+++ b/lang_sam/models/gdino.py
@@ -6,10 +6,27 @@ from lang_sam.models.utils import DEVICE
 
 
 class GDINO:
-    def build_model(self, ckpt_path: str | None = None, device=DEVICE):
-        model_id = "IDEA-Research/grounding-dino-base" if ckpt_path is None else ckpt_path
-        self.processor = AutoProcessor.from_pretrained(model_id)
-        self.model = AutoModelForZeroShotObjectDetection.from_pretrained(model_id).to(device)
+    def build_model(self, model_ckpt_path: str | None = None, processor_ckpt_path: str | None = None, device=DEVICE):
+        if not model_ckpt_path or not processor_ckpt_path: # indicates that we somehow able to load the model from internet
+            model_id = "IDEA-Research/grounding-dino-base"
+            print(f"One or both local paths not provided. Loading from Hugging Face Hub: {model_id}")
+            self.processor = AutoProcessor.from_pretrained(model_id)
+            self.model = AutoModelForZeroShotObjectDetection.from_pretrained(model_id).to(device)
+
+        else:
+            print(f"Attempting to load processor from local path: {processor_ckpt_path}")
+            self.processor = AutoProcessor.from_pretrained(
+                processor_ckpt_path,
+                local_files_only=True,        # never goes online
+                trust_remote_code=True,       # Grounding-DINO uses custom code
+            )
+            print(f"Attempting to load model from local path: {model_ckpt_path}")
+            self.model = AutoModelForZeroShotObjectDetection.from_pretrained(
+                model_ckpt_path,
+                local_files_only=True,
+                trust_remote_code=True,
+                use_safetensors=True,
+            ).to(device)
 
     def predict(
         self,


### PR DESCRIPTION
PR Description:

This PR enhances the GDINO class to accept distinct paths for its model and processor checkpoints, enabling more flexible, reliable, and explicit local loading capabilities.

Context & Problem:

Previously, GDINO would consistently download assets from the Hugging Face Hub. This was primarily because the calling script (e.g., within lang_sam.py) did not supply arguments for local checkpoint paths, even though GDINO's class definition could notionally accept them. For instance, GDINO was initialized without specific local path arguments:

```python
# Snippet from lang_sam.py (illustrating previous initialization)
13    self.sam = SAM()
14    self.sam.build_model(sam_type, ckpt_path, device=device)
15    self.gdino = GDINO()
16    self.gdino.build_model(model_ckpt_path=gdino_model_ckpt_path, processor_ckpt_path=gdino_processor_ckpt_path, device=device)
```

Solution Implemented:
```python
13    self.sam = SAM()
14    self.sam.build_model(sam_type, ckpt_path, device=device)
15    self.gdino = GDINO()
16    self.gdino.build_model(device=device)
```

To address this and provide better control over local asset usage, GDINO's build_model method has been modified as well. It now explicitly handles model_ckpt_path and processor_ckpt_path parameters, prioritizing local loading when these are provided:

```python
# Snippet of the new loading logic within GDINO's build_model
10         if not model_ckpt_path or not processor_ckpt_path:
11             model_id = "IDEA-Research/grounding-dino-base"
12             print(f"One or both local paths not provided. Loading from Hugging Face Hub: {model_id}")
13             self.processor = AutoProcessor.from_pretrained(model_id)
14             self.model = AutoModelForZeroShotObjectDetection.from_pretrained(model_id).to(device) 

15         else: # Both local paths are provided
16             print(f"Attempting to load processor from local path: {processor_ckpt_path}")
17             self.processor = AutoProcessor.from_pretrained(
18                 processor_ckpt_path,
19                 local_files_only=True,        # Enforces local-only loading
20                 trust_remote_code=True,       # Required for Grounding-DINO custom code
21             )
22             print(f"Attempting to load model from local path: {model_ckpt_path}")
23             self.model = AutoModelForZeroShotObjectDetection.from_pretrained(
24                 model_ckpt_path,
25                 local_files_only=True,
26                 trust_remote_code=True,
27                 use_safetensors=True,
28             ).to(device)
```

Key Features of this Refactor:

*    Explicit Path Handling: GDINO now clearly defines and utilizes separate parameters for model_ckpt_path and processor_ckpt_path.
*    Local Loading Priority: The system prioritizes loading from these specified local paths when both are provided.
*    Graceful Fallback: It falls back to downloading from the Hugging Face Hub only if local paths are not fully specified or if loading from local paths (with local_files_only=True) encounters an issue (though the snippet shown doesn't explicitly show error handling for the else block, the local_files_only=True would cause an error if files are missing, which then might need a try-except to fallback if that's desired behavior for failed local attempts).

Benefits:

This change allows for effective offline operation and provides users with more granular control when using local model and processor assets with GDINO.

Documentation:

I also have updated readme to indicate these arguments.

[x] I have performed a self-review of my code.
[ ] I have performed linting on my code. (See explanation below)
[ ] I have linked the related issue. (Link it if there is one)
[x] The code is documented accordingly.
[ ] If it is a core feature, I have added thorough tests.
