### PR TITLE
Fix batched inference for text with different size

### DIFF
--- a/lang_sam/models/gdino.py
+++ b/lang_sam/models/gdino.py
@@ -35,10 +35,10 @@ class GDINO:
         box_threshold: float,
         text_threshold: float,
     ) -> list[dict]:
-        for i, prompt in enumerate(texts_prompt):
-            if prompt[-1] != ".":
-                texts_prompt[i] += "."
-        inputs = self.processor(images=images_pil, text=texts_prompt, return_tensors="pt").to(self.model.device)
+        texts_prompt = [prompt if prompt[-1] == "." else prompt + "." for prompt in texts_prompt]
+        inputs = self.processor(
+            images=images_pil, text=texts_prompt, padding=True, return_tensors="pt"
+        ).to(self.model.device)
         with torch.no_grad():
             outputs = self.model(**inputs)
 


### PR DESCRIPTION
This PR fixes a bug in lang-sam when trying to run batched inference with different text prompts that were tokenized to different-sized sequences. To do so, I just enabled padding during the tokenization.
As a small extra, when `lang-sam` adds dots (".") at the end of the prompts, it does not mutate the provided text list.

## Describe your changes and approach used
Fixes #110 

## Checklist before requesting a review
- [x] I have performed a self-review of my code.
- [x] I have performed linting on my code.
- [x] I have linked the related issue.
- [x] The code is documented accordingly.
- [x] If it is a core feature, I have added thorough tests.