### PR TITLE
Fix and relax dependencies versioning - support transformers>=4.49.0

### DIFF
--- a/lang_sam/models/gdino.py
+++ b/lang_sam/models/gdino.py
@@ -45,7 +45,7 @@ class GDINO:
         results = self.processor.post_process_grounded_object_detection(
             outputs,
             inputs.input_ids,
-            box_threshold=box_threshold,
+            box_threshold,
             text_threshold=text_threshold,
             target_sizes=[k.size[::-1] for k in images_pil],
         )

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,8 @@
-gradio==5.29.0
-litserve==0.2.8
-opencv-python-headless==4.10.0.84
-pydantic>=2.9.2
+gradio>=5.29.0
+litserve>=0.2.8
+opencv-python-headless>=4.10.0.84
 sam-2 @ git+https://github.com/facebookresearch/segment-anything-2@c2ec8e14a185632b0a5d8b161928ceb50197eddc
-supervision==0.23.0 ; python_full_version >= '3.10'
-transformers==4.44.2
-uvloop==0.20.0
-torch==2.4.1
-torchvision==0.19.1
+supervision>=0.23.0
+transformers>=4.44.2
+torch>=2.3.1
+torchvision>=0.18.1


### PR DESCRIPTION
## Describe your changes and approach used

This PR fixes the dependencies versioning when solving for environments in `python==3.10`. Also, relaxes the fixed dependencies versioning to increase compatibility with more codebases. Unused dependencies where removed.

Finally, following release 4.49.0 of `transformers` that implemented huggingface/transformers#34853 , we supply `box_threshold` as a positional argument in `post_process_grounded_object_detection` instead of a keyword argument.

Fixes #109 

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] I have performed linting on my code.
- [x] I have linked the related issue.
- [x] The code is documented accordingly.
- [x] If it is a core feature, I have added thorough tests.